### PR TITLE
fixed device name and ioctl / device exclusion and inclusion

### DIFF
--- a/ioctl_hunter/frida/script.ts
+++ b/ioctl_hunter/frida/script.ts
@@ -60,8 +60,8 @@ var open_handles = {}
 //
 
 rpc.exports = {
-    exclude_ioctl: function (ioctl) {
-        excluded_ioctl.push(+ioctl);
+    excludeioctl: function (ioctl) {
+        excluded_ioctl.push(ioctl);
         return excluded_ioctl;
     },
     sethookenabled: function (bool) {
@@ -98,13 +98,13 @@ function getPathByHandle(handle) {
     var ret = Func_NtQueryObject(handle, 1, ptr, 1024, ptr2)
 
     if (x32) {
-        var path = Memory.readUtf16String(ptr.add(8))   // 32 bits binaries
+        var path = Memory.readUtf16String(Memory.readPointer(ptr.add(8)))   // 32 bits binaries
     }
     else {
-        var path = Memory.readUtf16String(ptr.add(16))  // 64 bits binaries
+        var path = Memory.readUtf16String(Memory.readPointer(ptr.add(16)))  // 64 bits binaries
     }
 
-    return path
+    return path.replaceAll("\\", "\\\\")
 }
 
 //

--- a/ioctl_hunter/lib/hooking.py
+++ b/ioctl_hunter/lib/hooking.py
@@ -42,6 +42,8 @@ def check_ioctls_filters(ioctl_dict):
         return ioctl_dict["ioctl"] in State.results.included_ioctls
     elif State.results.excluded_ioctls:
         return ioctl_dict["ioctl"] not in State.results.excluded_ioctls
+    else:
+        return True
 
 
 def process_device_ioctl_queue():


### PR DESCRIPTION
Hey, 

I have fixed the device path that was previously sending junk bytes from memory instead of the real path. It needs a pointer deference (`Memory.readPointer()`) before reading the UTF-16 string.

I have also fixed the inclusion / exlusion of driver and ioctl as it was not working. Before, a given driver / ioctl to include would also include all others not wanted.

Thanks for your tool.